### PR TITLE
Fix bugs with is_valid for pms5003 packets

### DIFF
--- a/src/packets/pms5003_packet.cpp
+++ b/src/packets/pms5003_packet.cpp
@@ -5,8 +5,9 @@ PMS5003Packet::PMS5003Packet() {
 }
 
 bool PMS5003Packet::is_valid() const {
-  return PMSPacketInterface::is_valid() ||
-    (calculated_checksum() == (checksum_hi * 256 + checksum_lo));
+  if (!PMSPacketInterface::is_valid()) return false;
+  if (calculated_checksum() != (checksum_hi * 256 + checksum_lo)) return false;
+  return true;
 }
 
 size_t PMS5003Packet::packet_size() const {

--- a/src/packets/pms5003_packet.h
+++ b/src/packets/pms5003_packet.h
@@ -6,8 +6,8 @@
 class PMS5003Packet : public PMSPacketInterface {
 public:
   PMS5003Packet();
-  bool is_valid() const;
-  size_t packet_size() const;
+  virtual bool is_valid() const;
+  virtual size_t packet_size() const;
 
   byte np3_hi; // Data7 indicates the number of particles with diameter beyond 0.3 um in 0.1 L of air.
   byte np3_lo;

--- a/src/packets/pms_packet_interface.h
+++ b/src/packets/pms_packet_interface.h
@@ -7,7 +7,7 @@
 
 class PMSPacketInterface : public Printable {
 public:
-  bool is_valid() const;
+  virtual bool is_valid() const;
   void reset();
   float pm1() const;
   float pm25() const;


### PR DESCRIPTION
I found two bugs with the pms5003 checksum
1) The `PMS5003Packet::is_valid` was incorrect such that a `true` value returned from `PMSPacketInterface::is_valid()` would cause `is_valid` to return `true` without checking the checksum
2) The `is_valid` method wasn't declared virtual, so any code that called `is_valid` on a `PMSPacketInterface *` typed pointer to a `PMS5003Packet` would only execute `PMSPacketInterface::is_valid()`

Overall, thanks for the code, it's been really helpful!